### PR TITLE
Updating nvim deprecated validation (for 1.0)

### DIFF
--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -23,7 +23,7 @@ local function validate_options(options)
 		"fallback",
 		options.fallback,
 		"boolean",
-		vim.tbl_contains({ "dark", "light" }, options),
+		vim.tbl_contains({ "dark", "light" }, options.fallback),
 		"`fallback` to be either 'light' or 'dark'"
 	)
 	vim.validate("set_dark_mode", options.set_dark_mode, "function")

--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -24,7 +24,7 @@ local function validate_options(options)
         options.fallback,
         function(opt)
             return vim.tbl_contains({ "dark", "light" }, opt)
-	    end,
+        end,
         "`fallback` to be either 'light' or 'dark'",
     )
 	vim.validate("set_dark_mode", options.set_dark_mode, "function")

--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -20,13 +20,12 @@ local default_options = {
 ---@param options AutoDarkModeOptions
 local function validate_options(options)
 	vim.validate(
-        "fallback",
-        options.fallback,
-        function(opt)
-            return vim.tbl_contains({ "dark", "light" }, opt)
-        end,
-        "`fallback` to be either 'light' or 'dark'",
-    )
+		"fallback",
+		options.fallback,
+		"boolean",
+		vim.tbl_contains({ "dark", "light" }, options),
+		"`fallback` to be either 'light' or 'dark'"
+	)
 	vim.validate("set_dark_mode", options.set_dark_mode, "function")
 	vim.validate("set_light_mode", options.set_light_mode, "function")
 	vim.validate("update_interval", options.update_interval, "number")

--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -19,18 +19,17 @@ local default_options = {
 
 ---@param options AutoDarkModeOptions
 local function validate_options(options)
-	vim.validate({
-		fallback = {
-			options.fallback,
-			function(opt)
-				return vim.tbl_contains({ "dark", "light" }, opt)
-			end,
-			"`fallback` to be either 'light' or 'dark'",
-		},
-		set_dark_mode = { options.set_dark_mode, "function" },
-		set_light_mode = { options.set_light_mode, "function" },
-		update_interval = { options.update_interval, "number" },
-	})
+	vim.validate(
+        "fallback",
+        options.fallback,
+        function(opt)
+            return vim.tbl_contains({ "dark", "light" }, opt)
+	    end,
+        "`fallback` to be either 'light' or 'dark'",
+    )
+	vim.validate("set_dark_mode", options.set_dark_mode, "function")
+	vim.validate("set_light_mode", options.set_light_mode, "function")
+	vim.validate("update_interval", options.update_interval, "number")
 
 	M.state.setup_correct = true
 end

--- a/lua/auto-dark-mode/init.lua
+++ b/lua/auto-dark-mode/init.lua
@@ -19,13 +19,9 @@ local default_options = {
 
 ---@param options AutoDarkModeOptions
 local function validate_options(options)
-	vim.validate(
-		"fallback",
-		options.fallback,
-		"boolean",
-		vim.tbl_contains({ "dark", "light" }, options.fallback),
-		"`fallback` to be either 'light' or 'dark'"
-	)
+	vim.validate("fallback", options.fallback, function(opt)
+		return vim.tbl_contains({ "dark", "light" }, opt)
+	end, "`fallback` to be either 'light' or 'dark'")
 	vim.validate("set_dark_mode", options.set_dark_mode, "function")
 	vim.validate("set_light_mode", options.set_light_mode, "function")
 	vim.validate("update_interval", options.update_interval, "number")


### PR DESCRIPTION
Fixed :checkhealth warning:
 vim.validate is deprecated. Feature will be removed in Nvim 1.0
  - ADVICE:
    - use vim.validate(name, value, validator, optional_or_msg) instead.
    - stack traceback: /home/fea/.local/share/nvim/lazy/auto-dark-mode.nvim/lua/auto-dark-mode/init.lua:22 /home/fea/.local/share/nvim/lazy/auto-dark-mode.nvim/lua/auto-dark-mode/init.lua:163 /home/fea/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:387